### PR TITLE
Support deleting remote S3 files when no longer present locally and specify s3cfg path.

### DIFF
--- a/s4cmd.py
+++ b/s4cmd.py
@@ -466,7 +466,7 @@ class S3Handler(object):
     s3cfg_path = None
     try:
       if opt.config != None:
-        s3cfg_path = "%s/.s3cfg" % opt.config
+        s3cfg_path = "%s" % opt.config
       else:
         s3cfg_path = "%s/.s3cfg" % os.environ["HOME"]
       if not os.path.exists(s3cfg_path):


### PR DESCRIPTION
This doesn't support deleting things locally that aren't present in S3 yet, since I don't use that feature, but it does support delete remote files that no longer exist locally (since I do use that feature) from s3cmd.
