### PR TITLE
Python3 Compatibility

### DIFF
--- a/s4cmd.py
+++ b/s4cmd.py
@@ -1473,3 +1473,4 @@ if __name__ == '__main__':
 #   - 1.5.20: Merge change from oniltonmaciel@github for arguments for multi-part upload.
 #             Fix setup.py for module and command line tool
 #   - 1.5.21: Merge changes from linsomniac@github for better argument parsing
+#   - 1.5.22: Add compatibility for Python3

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ from setuptools import setup, find_packages
 __author__ = "Chou-han Yang"
 __copyright__ = "Copyright 2014 BloomReach, Inc."
 __license__ = "http://www.apache.org/licenses/LICENSE-2.0"
-__version__ = "1.5.20"
+__version__ = "1.5.22"
 __maintainer__ = __author__
 __status__ = "Development"
 


### PR DESCRIPTION
I want to use `s4cmd` for a Python3 project and this pull request adds compatibility for both Python 2 and 3. This is possible because `boto` added Python3 support in Aug. 2014. [1] 

I did most of the fixes using the built-in 2to3 converter, but there were also some other small cases to deal with. I have run `run-tests.sh` and get the same output as before and after. I have also (anecdotally) confirmed that using `ls`, `get`, `put`, `cp`, etc. work on both Python 2 and 3 in my project.

[1] https://aws.amazon.com/blogs/aws/boto-python-3/