### PR TITLE
initial bash completion script to implement requested feature: Command-line auto-complete

### DIFF
--- a/bash-completion/s4cmd
+++ b/bash-completion/s4cmd
@@ -1,0 +1,70 @@
+_s4cmd ()
+{
+    local IFS=$' \n'
+    local cur prev words cword possibleparams
+    command=${COMP_WORDS[1]}
+    prev=${COMP_WORDS[COMP_CWORD-1]}
+    prevprev=${COMP_WORDS[COMP_CWORD-2]}
+    _init_completion || return
+
+    #echo -e "\nCurrent: $cur : Prev: $prev : Words: $words : Cword: $cword : Command: $command\n"
+    if [[ $cword -eq 1 ]]; then
+        #command
+        COMPREPLY=( $( compgen -W 'ls put get cp mv sync del du' -- "$cur" ) )
+        COMPREPLY=("${COMPREPLY[@]/%/ }")
+    elif [[ $cword -ge 2 ]]; then
+      params=${COMP_WORDS[@]:2}
+      if [ "$prevprev" == "s3" ]
+      then
+        #get initial bucket names
+        if [[ $cur =~ ^\/\/$ ]]; then
+          buckets=`s4cmd ls 2>/dev/null | grep -Eo "s3://.*" | grep -Eo "//.*"`
+          COMPREPLY=( $( compgen -W "$buckets" -- "$cur" ) )
+          return 0
+        
+        #help get buckets full names
+        elif [[ $cur =~ ^\/\/[^\/]*$ ]]; then
+            buckets=`s4cmd ls 2>/dev/null | grep -Eo "s3://.*" | grep -Eo "//.*"`
+            COMPREPLY=( $( compgen -W "$buckets" -- "$cur" ) )
+            return 0
+
+        #get contents of dir 
+        elif [[ $cur =~ ^\/\/.*\/$ ]]; then
+            buckets=`s4cmd ls s3:$cur 2>/dev/null | grep -Eo "s3://.*" | grep -Eo "//.*"`
+            COMPREPLY=( $( compgen -W "$buckets" -- "$cur" ) )
+            return 0
+  
+        #help get buckets contents
+        elif [[ $cur =~ ^\/\/.*\/.*$ ]]; then
+            checkdir=`dirname "$cur"`
+            buckets=`s4cmd ls s3:$checkdir 2>/dev/null | grep -Eo "s3://.*" | grep -Eo "//.*"`
+            COMPREPLY=( $( compgen -W "$buckets" -- "$cur" ) )
+            return 0
+        fi
+      fi
+      case "$command" in
+        ls)
+          COMPREPLY=( $( compgen -W "--recursive --show-directory" -- "$cur" ) )
+          COMPREPLY=("${COMPREPLY[@]/%/ }")
+          return 0
+          ;;
+        put|get|sync|cp|mv)
+          COMPREPLY=( $( compgen -W "--recursive --sync-check --force --dry-run" -- "$cur" ) )
+          COMPREPLY=("${COMPREPLY[@]/%/ }")
+          return 0
+          ;;
+        del)
+          COMPREPLY=( $( compgen -W "--recursive --dry-run" -- "$cur" ) )
+          COMPREPLY=("${COMPREPLY[@]/%/ }")
+          return 0
+          ;;
+        du)
+          COMPREPLY=( $( compgen -W "--recursive" -- "$cur" ) )
+          COMPREPLY=("${COMPREPLY[@]/%/ }")
+          return 0
+          ;;
+      esac
+    fi
+} &&
+complete -o nospace -o default -F _s4cmd s4cmd
+


### PR DESCRIPTION
can be sourced the usual ways:
	. ./bash-completion/s4cmd
	putting it in /etc/bash_completion.d/
	best bet: put it in ~/.bash_completion

supports all commands listed on github, with all optional dash dash parameters listed on github
supports rudimentary s3:// "filesystem" completion, similiar to directory completion built into bash

the command:
	s4cmd [tab]

should output:
cp     del    du     get    ls     mv     put    sync

the command:
	s4cmd ls [tab][tab]

more tabs from that point expand:
	--recursive        --show-directory

assuming you have your s3cfg set up s3 completion can handle the following 4 cases for s3 "directory/filename" completion.
assuming there is only one option, this auto complete will chose that automatically and not print output as listed below.

1) resolving bucket names
	s4cmd (ls|put|get|etc) s3://[tab][tab]
	should output:
	//bucketname //bucketname2 //bucketname3 //otherbucketname
2) resolving partial bucket names
	s4cmd (ls|put|get|etc) s3://bucket[tab][tab]
        should output:
        //bucketname //bucketname2 //bucketname3
3) resolving a "pathname" with trailing slash to "dirs" and "files"
	s4cmd (ls|put|get|etc) s3://bucketname/path/[tab][tab]
        should output:
        //bucketname/path/file1 //bucketname/path/file2 //bucketname/path/dir1/
4) resolving a partial "pathname" without trailing slash
	s4cmd (ls|put|get|etc) s3://bucketname/pa[tab][tab]
        should output:
        //bucketname/path/ //bucketname/filename1

todo:
	1) make s3:// completion only output trailing part of "dir" in s3, similar to dir listing completion in reg bash
issues:
	1) s3:// completion would be comically slow without some kind of caching of results,but caching is very probably a bad idea.
	2) error handling