### PR TITLE
Add requirement for pytz

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(name='s4cmd',
       url='https://github.com/bloomreach/s4cmd',
       py_modules=['s4cmd'],
       scripts=['s4cmd', 's4cmd.py'], # Added s4cmd.py as script for backward compatibility
-      install_requires=['boto3>=1.3.1'],
+      install_requires=['boto3>=1.3.1', 'pytz>=2016.4'],
       data_files=[('/etc/bash_completion.d/',['data/bash-completion/s4cmd'])],
       cmdclass={'install': install},
     )


### PR DESCRIPTION
s4cmd uses pytz to work with timezone aware datetimes, but doesn't require it in `setup.py`. 

I ran into this problem when trying to install s4cmd from pip and it was still missing a dependency 