### PR TITLE
Add a `cat` command that lets  you print files out directly

### DIFF
--- a/s4cmd.py
+++ b/s4cmd.py
@@ -837,7 +837,7 @@ class S3Handler(object):
     for source in sources:
       s3url = S3URL(source)
       response = self.s3.get_object(Bucket=s3url.bucket, Key=s3url.path)
-      message(response['Body'].read())
+      message('%s', response['Body'].read())
 
   @log_calls
   def get_single_file(self, pool, source, target):

--- a/s4cmd.py
+++ b/s4cmd.py
@@ -830,6 +830,16 @@ class S3Handler(object):
       os.chmod(target, int(obj['Metadata']['privilege'], 8))
 
   @log_calls
+  def print_files(self, source):
+    '''Print out a series of files'''
+    sources = self.source_expand(source)
+
+    for source in sources:
+      s3url = S3URL(source)
+      response = self.s3.get_object(Bucket=s3url.bucket, Key=s3url.path)
+      message(response['Body'].read())
+
+  @log_calls
   def get_single_file(self, pool, source, target):
     '''Download a single file or a directory by adding a task into queue'''
     if source[-1] == PATH_SEP:
@@ -1632,6 +1642,15 @@ class CommandHandler(object):
     source = args[1]
     target = args[2]
     self.s3handler().get_files(source, target)
+
+  @log_calls
+  def cat_handler(self, args):
+    '''Handler for cat command'''
+
+    self.validate('cmd|s3', args)
+    source = args[1]
+
+    self.s3handler().print_files(source)
 
   @log_calls
   def dsync_handler(self, args):

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ from setuptools.command.install import install as _install
 __author__ = "Chou-han Yang"
 __copyright__ = "Copyright 2014 BloomReach, Inc."
 __license__ = "http://www.apache.org/licenses/LICENSE-2.0"
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 __maintainer__ = __author__
 __status__ = "Development"
 


### PR DESCRIPTION
A common use case when using s4cmd interactively from the command line is to just print out some small configuration file or somesuch in a bucket somewhere. The cycle of downloading, cat-ing, and then deleting is annoying. This lets you just do:

    s4cmd cat s3://path/to/file.txt

and be on your merry way.