### PR TITLE
Add an `edit` command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ from setuptools.command.install import install as _install
 __author__ = "Chou-han Yang"
 __copyright__ = "Copyright 2014 BloomReach, Inc."
 __license__ = "http://www.apache.org/licenses/LICENSE-2.0"
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 __maintainer__ = __author__
 __status__ = "Development"
 


### PR DESCRIPTION
If you liked [`s4cmd cat`](https://github.com/bloomreach/s4cmd/pull/69) then you'll love `s4cmd edit` :smile: 
This allows in-place editing of files to a tmp file that is then transparently uploaded to S3. Much easier than s4cmd get + vim + s4cmd put.

![output](https://cloud.githubusercontent.com/assets/14872/16999929/68e23056-4e8e-11e6-808d-63edd778cb94.gif)