### PR TITLE
don't fail on zero length files

### DIFF
--- a/s4cmd.py
+++ b/s4cmd.py
@@ -1285,6 +1285,8 @@ class ThreadUtil(S3Handler, ThreadPool.Worker):
   @log_calls
   def read_file_chunk(self, source, pos, chunk):
     '''Read local file cunks'''
+    if chunk==0:
+        return StringIO()
     data = None
     with open(source, 'rb') as f:
       f.seek(pos)


### PR DESCRIPTION
s4cmd was failing to copy zero length files (hosted on an EFS (i.e. NFS) filesystem FWIW).  This fixes it - bit surprised this hasn't been hit before so maybe there's something odd happening.
