### PR TITLE
allow for s3 endpoint param

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,9 @@ seconds to sleep between retries
 ##### `-c NUM_THREADS, --num-threads=NUM_THREADS`
 number of concurrent threads
 
+##### `--endpoint-url`
+endpoint url used in boto3 client
+
 ##### `-d, --show-directory`
 show directory instead of its content
 

--- a/s4cmd.py
+++ b/s4cmd.py
@@ -384,9 +384,10 @@ class BotoClient(object):
     if (aws_access_key_id is not None) and (aws_secret_access_key is not None):
       self.client = self.boto3.client('s3',
                                       aws_access_key_id=aws_access_key_id,
-                                      aws_secret_access_key=aws_secret_access_key)
+                                      aws_secret_access_key=aws_secret_access_key,
+                                      endpoint_url=opt.endpoint_url)
     else:
-      self.client = self.boto3.client('s3')
+      self.client = self.boto3.client('s3', endpoint_url=opt.endpoint_url)
 
     # Cache the result so we don't have to recalculate.
     self.legal_params = {}
@@ -1835,6 +1836,9 @@ if __name__ == '__main__':
   parser.add_option(
       '--ignore-empty-source', help='ignore empty source from s3',
       dest='ignore_empty_source', action='store_true', default=False)
+  parser.add_option(
+      '--endpoint-url', help='configure boto3 to use a different s3 endpoint',
+      dest='endpoint_url', type='string', default=None)
   parser.add_option(
       '--use-ssl', help='(obsolete) use SSL connection to S3', dest='use_ssl',
       action='store_true', default=False)


### PR DESCRIPTION
I want to be able to use s3 transfer accelerated buckets with s4cmd.  Boto3 allows for this by configuring a `endpoint_url` in the s3 client.  With this change, I can enable s3 transfer acceleration by using `--endpoint-url=http://s3-accelerate.amazonaws.com`
