### PR TITLE
Include sync check for dry run and reduce spamming

### DIFF
--- a/s4cmd.py
+++ b/s4cmd.py
@@ -1306,10 +1306,13 @@ class ThreadUtil(S3Handler, ThreadPool.Worker):
 
       # optional checks
       if self.opt.dry_run:
-        message('%s => %s', source, target)
+        if self.opt.sync_check and self.sync_check(md5cache, obj):
+          info('%s => %s (synced)', source, target)
+        else:
+          message('%s => %s', source, target)
         return
       elif self.opt.sync_check and self.sync_check(md5cache, obj):
-        message('%s => %s (synced)', source, target)
+        info('%s => %s (synced)', source, target)
         return
       elif not self.opt.force and obj:
         raise Failure('File already exists: %s' % target)


### PR DESCRIPTION
It's convenient to be able to use --dry-run to see what changes would be synced when syncing directories.

If syncing a previously synced directory, the dry-run step must include the sync_check (ie check of md5 hash) to be able to indicate what will be uploaded.

Also, if there are many files where only a handful have changed there will be a lot of spam with "(synced)" entries of all the unchanged files, so only print these lines if verbose output is enabled.

These changes makes the output of s4cmd look more like s3cmd when syncing directories.