### PR TITLE
Remove S3 key check to allow full boto auth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ a single file!)
 - If you already have a `~/.s3cfg` file from configuring `s3cmd`, credentials
 from this file will be used.  Otherwise, set the `S3_ACCESS_KEY` and
 `S3_SECRET_KEY` environment variables to contain your S3 credentials.
+- If no keys are provided, but an IAM role is associated with the EC2 instance, it will
+be used transparently.
 
 
 ## s4cmd Commands

--- a/s4cmd.py
+++ b/s4cmd.py
@@ -271,6 +271,7 @@ class BotoClient(object):
   # Exported exceptions.
   BotoError = boto3.exceptions.Boto3Error
   ClientError = botocore.exceptions.ClientError
+  NoCredentialsError = botocore.exceptions.NoCredentialsError
 
   # Exceptions that retries may work. May change in the future.
   S3RetryableErrors = (
@@ -1890,14 +1891,14 @@ if __name__ == '__main__':
 
   # Initalize keys for S3.
   S3Handler.init_s3_keys(opt)
-  if S3Handler.S3_KEYS is None:
-    fail('[Invalid Argument] access key or secret key is not provided ', status = -1)
   try:
     CommandHandler(opt).run(args)
   except InvalidArgument as e:
     fail('[Invalid Argument] ', exc_info=e)
   except Failure as e:
     fail('[Runtime Failure] ', exc_info=e)
+  except BotoClient.NoCredentialsError as e:
+    fail('[Invalid Argument] ', exc_info=e)
   except BotoClient.BotoError as e:
     fail('[Boto3Error] %s: %s' % (e.error_code, e.error_message))
   except Exception as e:


### PR DESCRIPTION
Boto has a rich set of search methods to attempt to locate credentials. Currently s4cmd doesn't allow authentication to even be attempted without the secret key and access key. This means that s4cmd can't be used with IAM roles. 

Full boto auth search pattern can be found [here](http://boto3.readthedocs.io/en/latest/guide/configuration.html#guide-configuration)