### PR TITLE
Compare num_bytes written with size of chunk

### DIFF
--- a/s4cmd.py
+++ b/s4cmd.py
@@ -1367,7 +1367,9 @@ class ThreadUtil(S3Handler, ThreadPool.Worker):
     try:
       os.lseek(fd, pos, os.SEEK_SET)
       data = body.read(chunk)
-      os.write(fd, data)
+      num_bytes_written = os.write(fd, data)
+      if(num_bytes_written != len(data)):
+        raise RetryFailure('Number of bytes written inconsistent: %s != %s' % (num_bytes_written, sys.getsizeof(data)))
     finally:
       os.close(fd)
 


### PR DESCRIPTION
Fix for #101 

Runs a check comparing number of bytes written to size of the chunk in  write_file_chunk method