### PR TITLE
#88 (multiple) --exclude for local src files in dsync.

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Synchronize the contents of two directories. The directory can either be local o
 *   -f/--force: override existing file instead of showing error message.
 *   -n/--dry-run: emulate the operation without real sync.
 *   --delete-removed: delete files not in source directory.
+*   --exclude: exclude files with the given pattern(s). Only works for local files to be uploaded to s3 directory. This option can be provided several times.
 
 #### `s4cmd sync [source] [target]`
 
@@ -262,6 +263,9 @@ before given parameter.
 ##### `--last-modified-after=[datetime]`
 Condition on files where their last modified dates are
 after given parameter.
+
+##### `--exclude`
+(local) Filenames, matching the given pattern (https://docs.python.org/3.4/library/fnmatch.html) will not be synced to s3 directory. You may provide this param several times.
 
 
 ## S3 API Pass-through Options


### PR DESCRIPTION
Since i need to exclude local source files from syncing to s3 (according to several different patterns) when using dsync, i implemented it. The Option _--exclude_ is considered only for _dsync_s' _source dir_.