### PR TITLE
Make merge_opt_params compatible with Python 3

### DIFF
--- a/s4cmd.py
+++ b/s4cmd.py
@@ -429,7 +429,7 @@ class BotoClient(object):
       if key in kargs and type(kargs[key]) == dict:
         assert(type(getattr(self.opt, key)) == dict)
         # Merge two dictionaries.
-        for k, v in getattr(self.opt, key).iteritems():
+        for k, v in getattr(self.opt, key).items():
           kargs[key][k] = v
       else:
         # Overwrite values.


### PR DESCRIPTION
In Python 3 `iteritems` does not exist, so I was getting an `AttributeError`.

The command used was `s4cmd dsync --recursive --delete-removed --API-Metadata='{"Cache-Control": "max-age=31536000"}' build <my_bucket>`

```
[Exception] 'dict' object has no attribute 'iteritems'
Exception in thread Thread-10:d(s)]
Traceback (most recent call last):
  File "/Users/abutler/.local/pipx/venvs/s4cmd/bin/s4cmd.py", line 520, in run
    self.__class__.__dict__[func_name](self, *args, **kargs)
  File "/Users/abutler/.local/pipx/venvs/s4cmd/bin/s4cmd.py", line 129, in wrapper
    ret = func(*args, **kargs)
  File "/Users/abutler/.local/pipx/venvs/s4cmd/bin/s4cmd.py", line 1336, in upload
    'privilege': self.get_file_privilege(source)})
  File "/Users/abutler/.local/pipx/venvs/s4cmd/bin/s4cmd.py", line 399, in wrapped_method
    merged_kargs = self.merge_opt_params(method, kargs)
  File "/Users/abutler/.local/pipx/venvs/s4cmd/bin/s4cmd.py", line 432, in merge_opt_params
    for k, v in getattr(self.opt, key).iteritems():
AttributeError: 'dict' object has no attribute 'iteritems'
```