### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "bash"
+run = "python setup.py install ; pip install boto3 ; s4cmd -h"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # s4cmd
 ### Super S3 command line tool
 [![Build Status](https://travis-ci.com/bloomreach/s4cmd.svg?branch=master)](https://travis-ci.com/bloomreach/s4cmd) [![Join the chat at https://gitter.im/bloomreach/     s4cmd](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/bloomreach/s4cmd?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Run on Repl.it](https://repl.it/badge/github/bloomreach/s4cmd)](https://repl.it/github/bloomreach/s4cmd)
 
 ----
 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@Mosrod/s4cmd).