### PR TITLE
fix s3cfg_path handling when HOME does not exists

### DIFF
--- a/s4cmd.py
+++ b/s4cmd.py
@@ -648,8 +648,10 @@ class S3Handler(object):
     try:
       if opt.s3cfg != None:
         s3cfg_path = "%s" % opt.s3cfg
-      else:
+      elif 'HOME' in os.environ:
         s3cfg_path = "%s/.s3cfg" % os.environ["HOME"]
+      else:
+        return None
       if not os.path.exists(s3cfg_path):
         return None
       config = ConfigParser.ConfigParser()


### PR DESCRIPTION
following exception occurs when enviromental variable HOME is not set in s3_keys_from_s3cfg method

Exception UnboundLocalError: local variable 's3cfg_path' referenced before assignment

exception is triggered by accessing the dictionary key HOME which does not exist, resulting in s3cfg_path is not set. but then, the variable s3cfg_path is sadly used in the Exception handling.

this patch fixes this by checking the presence of HOME environmental variable. if not found, method returns None