### PR TITLE
Add support for Unsigned Requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,9 @@ debug output
 ##### `--validate`
 (obsolete) validate lookup operation
 
+##### `--no-sign-request`
+Makes unsigned request.
+
 ##### `-D, --delete-removed`
 delete remote files that do not exist in source after sync
 

--- a/s4cmd.py
+++ b/s4cmd.py
@@ -1884,7 +1884,7 @@ def main():
           action='store_true', default=False)
       parser.add_option(
           '--no-sign-request',
-          help='credentials will not be used while making connection if set.', dest='no_sign_request',
+          help='unsigned requests would be made if set.', dest='no_sign_request',
           action='store_true', default=False)
       parser.add_option(
           '-D', '--delete-removed',

--- a/s4cmd.py
+++ b/s4cmd.py
@@ -377,14 +377,8 @@ class BotoClient(object):
        for each method we are going to call.
     '''
     self.opt = opt
-    if (aws_access_key_id is not None) and (aws_secret_access_key is not None):
-      self.client = self.boto3.client('s3',
-                                      aws_access_key_id=aws_access_key_id,
-                                      aws_secret_access_key=aws_secret_access_key,
-                                      endpoint_url=opt.endpoint_url)
-    else:
-      self.client = self.boto3.client('s3', endpoint_url=opt.endpoint_url)
-
+    client_params = self._get_client_params(aws_access_key_id, aws_secret_access_key)
+    self.client = self.boto3.client('s3', **client_params)
     # Cache the result so we don't have to recalculate.
     self.legal_params = {}
     for method in BotoClient.ALLOWED_CLIENT_METHODS:
@@ -406,6 +400,16 @@ class BotoClient(object):
       return wrapped_method
 
     return super(BotoClient, self).__getattribute__(method)
+
+  def _get_client_params(self, aws_access_key_id=None, aws_secret_access_key=None):
+    client_params = {'endpoint_url': self.opt.endpoint_url}
+    if self.opt.no_sign_request:
+      client_params['config'] = self.botocore.config.Config(signature_version=self.botocore.UNSIGNED)
+    if (aws_access_key_id is not None) and (aws_secret_access_key is not None):
+      client_params['aws_access_key_id'] = aws_access_key_id
+      client_params['aws_secret_access_key'] = aws_secret_access_key
+
+    return client_params
 
   def get_legal_params(self, method):
     '''Given a API name, list all legal parameters using boto3 service model.'''
@@ -1877,6 +1881,10 @@ def main():
           action='store_true', default=False)
       parser.add_option(
           '--validate', help='(obsolete) validate lookup operation', dest='validate',
+          action='store_true', default=False)
+      parser.add_option(
+          '--no-sign-request',
+          help='credentials will not be used while making connection if set.', dest='no_sign_request',
           action='store_true', default=False)
       parser.add_option(
           '-D', '--delete-removed',


### PR DESCRIPTION
aws-cli and Boto3 both provide an option to fetch S3 objects from
public buckets without explicitly signing the request, using 
--no-sign-request flag.

s3cmd doesn't have a similar option as such, but this could be
useful to get started with s4cmd without any setup for public
buckets.

Refactored code to populate boto3 client params to a separate methods,
since there are other open issues to add such similar flags such as 


Fixes #139