### PR TITLE
Add a repology badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # s4cmd
 ### Super S3 command line tool
-[![Build Status](https://travis-ci.com/bloomreach/s4cmd.svg?branch=master)](https://travis-ci.com/bloomreach/s4cmd) [![Join the chat at https://gitter.im/bloomreach/     s4cmd](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/bloomreach/s4cmd?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://travis-ci.com/bloomreach/s4cmd.svg?branch=master)](https://travis-ci.com/bloomreach/s4cmd) [![Join the chat at https://gitter.im/bloomreach/     s4cmd](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/bloomreach/s4cmd?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Packaging status](https://repology.org/badge/tiny-repos/s4cmd.svg)](https://repology.org/project/s4cmd/versions)
 
 ----
 


### PR DESCRIPTION
It would be nice to have a [repology](https://repology.org) badge showing the number of packages.